### PR TITLE
fixes for ubuntu/debian

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,33 +1,48 @@
 dnl $Id: config.m4 321796 2012-01-05 17:23:48Z laruence $
 PHP_ARG_WITH(lua, for lua support,
 [  --with-lua=[DIR]    Include php lua support])
+PHP_ARG_WITH(lua-version, to specify a custom lua version, [  --with-lua-version=[VERSION]]   Use the specified lua version.)
 
 if test "$PHP_LUA" != "no"; then
   if test -r $PHP_LUA/include/lua.h; then
-    LUA_DIR=$PHP_LUA
+    LUA_INCLUDE_DIR=$PHP_LUA
   else
     AC_MSG_CHECKING(for lua in default path)
     for i in /usr/local /usr; do
       if test -r $i/include/lua/lua.h; then
-        LUA_DIR=$i
+        LUA_INCLUDE_DIR=$i/include/lua
         AC_MSG_RESULT(found in $i)
         break
+      fi
+
+      if test "$PHP_LUA_VERSION" != "yes"; then
+        if test -r $i/include/lua$PHP_LUA_VERSION/lua.h; then
+          LUA_INCLUDE_DIR=$i/include/lua$PHP_LUA_VERSION
+          AC_MSG_RESULT(found in a version-specific subdirectory of $i)
+          break
+        fi
       fi
     done
   fi
 
-  if test -z "$LUA_DIR"; then
+  if test -z "$LUA_INCLUDE_DIR"; then
     AC_MSG_RESULT(not found)
     AC_MSG_ERROR(Please reinstall the lua distribution - lua.h should be in <lua-dir>/include/)
   fi
 
-  LUA_LIB_NAME=liblua
+  if test "$PHP_LUA_VERSION" != "yes"; then
+    LUA_LIB_SUFFIX=lua$PHP_LUA_VERSION
+  else
+    LUA_LIB_SUFFIX=lua$PHP_LUA_VERSION
+  fi
+
+  LUA_LIB_NAME=lib$LUA_LIB_SUFFIX
 
   if test -r $PHP_LUA/$PHP_LIBDIR/${LUA_LIB_NAME}.${SHLIB_SUFFIX_NAME} -o -r $PHP_LUA/$PHP_LIBDIR/${LUA_LIB_NAME}.a; then
     LUA_LIB_DIR=$PHP_LUA/$PHP_LIBDIR
   else
     AC_MSG_CHECKING(for lua library in default path)
-    for i in /usr/$PHP_LIBDIR /usr/lib /usr/lib64; do
+    for i in /usr/$PHP_LIBDIR /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu; do
       if test -r $i/${LUA_LIB_NAME}.${SHLIB_SUFFIX_NAME} -o -r $i/${LUA_LIB_NAME}.a; then
         LUA_LIB_DIR=$i
         AC_MSG_RESULT(found in $i)
@@ -41,8 +56,8 @@ if test "$PHP_LUA" != "no"; then
     AC_MSG_ERROR(Please reinstall the lua distribution - lua library should be in <lua-dir>/lib/)
   fi
 
-  PHP_ADD_INCLUDE($LUA_DIR/include)
-  PHP_ADD_LIBRARY_WITH_PATH(lua, $LUA_LIB_DIR, LUA_SHARED_LIBADD)
+  PHP_ADD_INCLUDE($LUA_INCLUDE_DIR)
+  PHP_ADD_LIBRARY_WITH_PATH($LUA_LIB_SUFFIX, $LUA_LIB_DIR, LUA_SHARED_LIBADD) 
   PHP_SUBST(LUA_SHARED_LIBADD)
   PHP_NEW_EXTENSION(lua, lua.c lua_closure.c, $ext_shared)
 fi


### PR DESCRIPTION
this fixes - building against 5.5 and 5.6 
should be carried in seperated branch - because the php7 stuff is already in master


see test results on 5.5 and 5.6

    =====================================================================
    PHP         : /tmp/php5.5-bin/bin/php 
    PHP_SAPI    : cli
    PHP_VERSION : 5.5.22-dev
    ZEND_VERSION: 2.5.0
    PHP_OS      : Linux - Linux ip-172-31-14-228 3.2.0-4-amd64 #1 SMP Debian 3.2.63-2 x86_64
    INI actual  : /home/admin/tmp/php-lua/tmp-php.ini
    More .INIs  :  
    CWD         : /home/admin/tmp/php-lua
    Extra dirs  : 
    VALGRIND    : Not used
    =====================================================================
    TIME START 2015-02-02 16:07:24
    =====================================================================
    PASS Basic lua check [tests/001.phpt] 
    PASS Set and read properties [tests/002.phpt] 
    PASS Call lua functions [tests/003.phpt] 
    PASS Type conversion from lua to PHP [tests/004.phpt] 
    PASS Lua phpinfo() block [tests/005.phpt] 
    PASS Lua::include() [tests/006.phpt] 
    PASS Lua return function [tests/007.phpt] 
    PASS register php function to lua [tests/008.phpt] 
    PASS Bug (eval and include compute wrong return value number) [tests/009.phpt] 
    PASS LuaClosure exception [tests/010.phpt] 
    PASS register invalid php callback to lua [tests/011.phpt] 
    PASS Lua::include() with error codes [tests/012.phpt] 
    PASS PHP Closures from Lua [tests/013.phpt] 
    PASS Bug #65097 (nApplyCount release missing) [tests/bug65097.phpt] 
    =====================================================================
    TIME END 2015-02-02 16:07:24
    
    =====================================================================
    PHP         : /tmp/php5.6-bin/bin/php 
    PHP_SAPI    : cli
    PHP_VERSION : 5.6.6-dev
    ZEND_VERSION: 2.6.0
    PHP_OS      : Linux - Linux ip-172-31-14-228 3.2.0-4-amd64 #1 SMP Debian 3.2.63-2 x86_64
    INI actual  : /home/admin/tmp/php-lua/tmp-php.ini
    More .INIs  :  
    CWD         : /home/admin/tmp/php-lua
    Extra dirs  : 
    VALGRIND    : Not used
    =====================================================================
    TIME START 2015-02-02 16:09:35
    =====================================================================
    PASS Basic lua check [tests/001.phpt] 
    PASS Set and read properties [tests/002.phpt] 
    PASS Call lua functions [tests/003.phpt] 
    PASS Type conversion from lua to PHP [tests/004.phpt] 
    PASS Lua phpinfo() block [tests/005.phpt] 
    PASS Lua::include() [tests/006.phpt] 
    PASS Lua return function [tests/007.phpt] 
    PASS register php function to lua [tests/008.phpt] 
    PASS Bug (eval and include compute wrong return value number) [tests/009.phpt] 
    PASS LuaClosure exception [tests/010.phpt] 
    PASS register invalid php callback to lua [tests/011.phpt] 
    PASS Lua::include() with error codes [tests/012.phpt] 
    PASS PHP Closures from Lua [tests/013.phpt] 
    PASS Bug #65097 (nApplyCount release missing) [tests/bug65097.phpt] 
    =====================================================================
    TIME END 2015-02-02 16:09:36
