### PR TITLE
Explicitly release held references to PHP callbacks

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -63,6 +63,19 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_lua_free, 0, 0, 1)
 ZEND_END_ARG_INFO()
 /* }}} */
 
+static PHP_RSHUTDOWN_FUNCTION(lua) /* {{{ */
+{
+	zval *callbacks = zend_read_static_property(lua_ce, ZEND_STRL("_callbacks"), 1);
+
+	if (callbacks) {
+		zval_ptr_dtor(callbacks);
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+
 /* {{{ lua_module_entry
 */
 zend_module_entry lua_module_entry = {
@@ -74,7 +87,7 @@ zend_module_entry lua_module_entry = {
 	PHP_MINIT(lua),
 	PHP_MSHUTDOWN(lua),
 	NULL,
-	NULL,
+	PHP_RSHUTDOWN(lua),
 	PHP_MINFO(lua),
 #if ZEND_MODULE_API_NO >= 20010901
 	PHP_LUA_VERSION,


### PR DESCRIPTION
Noticed the leak while running `make test` in a debug build.  A few thoughts:

1. Letting the callbacks leak is probably not the worst thing in the world since we're only cleaning them up at RSHUTDOWN anyway.  So leaving out this patch would be marginally less correct even if marginally more performant.  Marginally either way.

2. Shouldn't these callable references exist on the Lua PHP object instance?  That way when the interpreter falls out of scope and we shutdown the Lua runtime, we can opportunistically free these references earlier (and avoid the RSHUTDOWN callback).