### PR TITLE
Fix allocation of lua object.

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -197,12 +197,7 @@ zend_object *php_lua_create_object(zend_class_entry *ce)
 
 	lua_atpanic(L, php_lua_atpanic);
 
-	intern = emalloc(sizeof(php_lua_object) + sizeof(zval) * (ce->default_properties_count - 1));
-
-	if (!intern) {
-		php_error_docref(NULL, E_ERROR, "alloc memory for lua object failed");
-	}
-
+	intern = ecalloc(1, sizeof(php_lua_object) + zend_object_properties_size(ce));
 	intern->L = L;
 
 	zend_object_std_init(&intern->obj, ce);


### PR DESCRIPTION
Size the malloc using zend's helper.
Use ecalloc over emalloc to make sure uninit'd structs are clear.
No need to check return value as e*alloc() funcs can't fail.