### PR TITLE
Refactor LuaClosure

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -556,13 +556,9 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 		}
 	} else if (IS_OBJECT == Z_TYPE_P(func)
 			&& instanceof_function(Z_OBJCE_P(func), php_lua_get_closure_ce())) {
-		zval *closure = zend_read_property(php_lua_get_closure_ce(), func, ZEND_STRL("_closure"), 1, &rv);
-		if (!Z_LVAL_P(closure)) {
-			zend_throw_exception_ex(lua_exception_ce, 0, "invalid lua closure");
-			return NULL;
-		}
+		lua_closure_object *closure_obj = php_lua_closure_object_from_zend_object(Z_OBJ_P(func));
 		bp = lua_gettop(L);
-		lua_rawgeti(L, LUA_REGISTRYINDEX, Z_LVAL_P(closure));
+		lua_rawgeti(L, LUA_REGISTRYINDEX, closure_obj->closure);
 		if (LUA_TFUNCTION != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -1);
 			zend_throw_exception_ex(lua_exception_ce, 0, "call to lua closure failed");

--- a/lua_closure.h
+++ b/lua_closure.h
@@ -19,6 +19,17 @@
 
 #ifndef LUA_CLOSURE_H
 #define LUA_CLOSURE_H
+typedef struct _lua_closure_object {
+	long closure;
+	zval lua;
+
+	zend_object std;
+} lua_closure_object;
+
+static inline lua_closure_object* php_lua_closure_object_from_zend_object(zend_object *zobj) {
+	return ((lua_closure_object*)(zobj + 1)) - 1;
+}
+
 void php_lua_closure_register();
 zend_class_entry *php_lua_get_closure_ce();
 zval * php_lua_closure_instance(zval *instance, long ref_id, zval *lua_obj);

--- a/php_lua.h
+++ b/php_lua.h
@@ -61,6 +61,7 @@ static inline php_lua_object *php_lua_obj_from_obj(zend_object *obj) {
   return (php_lua_object*)((char*)(obj)-XtOffsetOf(php_lua_object, obj));
 }
 
+#define Z_LUAVAL(obj)   php_lua_obj_from_obj(Z_OBJ((obj)))
 #define Z_LUAVAL_P(obj) php_lua_obj_from_obj(Z_OBJ_P((obj)))
 
 zval *php_lua_get_zval_from_lua(lua_State *L, int index, zval *lua_obj, zval *rv);


### PR DESCRIPTION
Use proper internal object storage rather than private props.
Favor NULL clone_obj handler over empty private __clone method.
Favor free_obj handler over __destruct() method.