### PR TITLE
去除Lua::_callbacks，解决内存持续增加的问题

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -175,15 +175,15 @@ static void php_lua_dtor_object(zend_object *object) /* {{{ */ {
 
 	zend_object_std_dtor(&(lua_obj->obj));
     
-    // zval_ptr_dtor callbacks
+	// zval_ptr_dtor callbacks
     
-    zval *callbacks = &lua_obj->callbacks;
-    zval *callback;
-    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(callbacks), callback) {
-        zval_ptr_dtor(callback);
-    } ZEND_HASH_FOREACH_END();
+	zval *callbacks = &lua_obj->callbacks;
+	zval *callback;
+	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(callbacks), callback) {
+		zval_ptr_dtor(callback);
+	} ZEND_HASH_FOREACH_END();
     
-    zval_ptr_dtor(callbacks);
+	zval_ptr_dtor(callbacks);
 }
 /* }}} */
 
@@ -215,8 +215,8 @@ zend_object *php_lua_create_object(zend_class_entry *ce)
 
 	intern->obj.handlers = &lua_object_handlers;
     
-    ZVAL_NULL(&intern->callbacks);
-    memcpy(lua_getextraspace(L), &intern, LUA_EXTRASPACE/* sizeof(void *) */);
+	ZVAL_NULL(&intern->callbacks);
+	memcpy(lua_getextraspace(L), &intern, LUA_EXTRASPACE/* sizeof(void *) */);
 
 	return &intern->obj;
 }
@@ -277,8 +277,8 @@ static int php_lua_call_callback(lua_State *L) {
 
 	order = lua_tonumber(L, lua_upvalueindex(1));
 
-    php_lua_object *lua_obj = *(php_lua_object **) lua_getextraspace(L);
-    callbacks = &lua_obj->callbacks;
+	php_lua_object *lua_obj = *(php_lua_object **) lua_getextraspace(L);
+	callbacks = &lua_obj->callbacks;
 	
 	if (ZVAL_IS_NULL(callbacks)) {
 		return 0;
@@ -425,8 +425,8 @@ try_again:
 				if (zend_is_callable(val, 0, NULL)) {
 					zval *callbacks;
 
-                    php_lua_object *lua_obj = *(php_lua_object **) lua_getextraspace(L);
-                    callbacks = &lua_obj->callbacks;
+					php_lua_object *lua_obj = *(php_lua_object **) lua_getextraspace(L);
+					callbacks = &lua_obj->callbacks;
 
 					if (ZVAL_IS_NULL(callbacks)) {
 						array_init(callbacks);

--- a/lua.c
+++ b/lua.c
@@ -786,8 +786,8 @@ PHP_METHOD(lua, registerCallback) {
 
 	L = (Z_LUAVAL_P(getThis()))->L;
 
-    php_lua_object *lua_obj = *(php_lua_object **) lua_getextraspace(L);
-    callbacks = &lua_obj->callbacks;
+	php_lua_object *lua_obj = *(php_lua_object **) lua_getextraspace(L);
+	callbacks = &lua_obj->callbacks;
 
 	if (ZVAL_IS_NULL(callbacks)) {
 		array_init(callbacks);
@@ -876,7 +876,7 @@ PHP_MINIT_FUNCTION(lua) {
 
 	//lua_ce->ce_flags |= ZEND_ACC_FINAL;
 
-	zend_declare_property_null(lua_ce, ZEND_STRL("_callbacks"), ZEND_ACC_STATIC|ZEND_ACC_PRIVATE);
+	//zend_declare_property_null(lua_ce, ZEND_STRL("_callbacks"), ZEND_ACC_STATIC|ZEND_ACC_PRIVATE);
 	zend_declare_class_constant_string(lua_ce, ZEND_STRL("LUA_VERSION"), LUA_RELEASE);
 
 	php_lua_closure_register();

--- a/php_lua.h
+++ b/php_lua.h
@@ -53,6 +53,7 @@ extern zend_module_entry lua_module_entry;
 struct _php_lua_object {
   lua_State *L;
   zend_object obj;
+  zval callbacks;
 };
 
 typedef struct _php_lua_object php_lua_object;


### PR DESCRIPTION
在 php_lua_object 结构体中建立 zval *callbacks 存放PHP闭包。利用 lua 的 extraspace 空间存储 php_lua_object 结构体。当需要 callbacks 的时候通过 lua_State 指针获得 php_lua_object 从而获得 callbacks。从而使 callbacks 随着 \Lua 对象的释放而释放

注意：使用到了 lua_getextraspace 函数，要求lua-5.0以上