### PR TITLE
Integer support

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -300,6 +300,12 @@ static int php_lua_call_callback(lua_State *L) {
 /* }}} */
 
 zval *php_lua_get_zval_from_lua(lua_State *L, int index, zval *lua_obj, zval *rv) /* {{{ */ {
+#if (LUA_VERSION_NUM >= 503)
+	if (lua_isinteger(L, index)) {
+		ZVAL_LONG(rv, lua_tointeger(L, index));
+		return rv;
+	}
+#endif
 	switch (lua_type(L, index)) {
 		case LUA_TNIL:
 			ZVAL_NULL(rv);
@@ -340,8 +346,10 @@ zval *php_lua_get_zval_from_lua(lua_State *L, int index, zval *lua_obj, zval *rv
 
 				switch (Z_TYPE(key)) {
 					case IS_DOUBLE:
-					case IS_LONG:
 						add_index_zval(rv, Z_DVAL(key), &val);
+						break;
+					case IS_LONG:
+						add_index_zval(rv, Z_LVAL(key), &val);
 						break;
 					case IS_STRING:
 						add_assoc_zval(rv, Z_STRVAL(key), &val);


### PR DESCRIPTION
在新版本的lua中已经可以区分integer和double了，这就可以解决扩展统一把lua的number类型转换成php的double的问题
```
$lua->eval("a=2");
// old
gettype($lua->a); // double
// new
gettype($lua->a); // integer
```