### PR TITLE
对LuaException进行定义：lua代码和error方法抛出的异常才是LuaException

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -543,8 +543,8 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 			   php_error_docref(NULL, E_WARNING,
 			   "invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
 			   */
-            zend_throw_exception_ex(NULL, 0, 
-					"invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
+			zend_throw_exception_ex(NULL, 0, 
+				"invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
 			return NULL;
 		}
 #if (LUA_VERSION_NUM < 502)
@@ -554,14 +554,14 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 #endif
 		if (LUA_TTABLE != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -1);
-            zend_throw_exception_ex(NULL, 0, "invalid lua table '%s'", Z_STRVAL_P(t));
+			zend_throw_exception_ex(NULL, 0, "invalid lua table '%s'", Z_STRVAL_P(t));
 			return NULL;
 		}
 		bp = lua_gettop(L);
 		lua_getfield(L, -1, Z_STRVAL_P(f));
 		if (LUA_TFUNCTION != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -2);
-            zend_throw_exception_ex(NULL, 0, "invalid lua table function '%s'.%s", Z_STRVAL_P(t), Z_STRVAL_P(f));
+			zend_throw_exception_ex(NULL, 0, "invalid lua table function '%s'.%s", Z_STRVAL_P(t), Z_STRVAL_P(f));
 			return NULL;
 		}
 	} else if (IS_STRING == Z_TYPE_P(func)) {
@@ -573,7 +573,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 #endif
 		if (LUA_TFUNCTION != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -1);
-            zend_throw_exception_ex(NULL, 0, "invalid lua function '%s'", Z_STRVAL_P(func));
+			zend_throw_exception_ex(NULL, 0, "invalid lua function '%s'", Z_STRVAL_P(func));
 			return NULL;
 		}
 	} else if (IS_OBJECT == Z_TYPE_P(func)
@@ -583,7 +583,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 		lua_rawgeti(L, LUA_REGISTRYINDEX, closure_obj->closure);
 		if (LUA_TFUNCTION != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -1);
-            zend_throw_exception_ex(NULL, 0, "call to lua closure failed");
+			zend_throw_exception_ex(NULL, 0, "call to lua closure failed");
 			return NULL;
 		}
 	}
@@ -623,15 +623,15 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 		lua_pop(L, -1);
 	}
     
-    if(ret != LUA_OK) {
-        zval lua_ex;
-        object_init_ex(&lua_ex, lua_exception_ce);
-        zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, retval);
-        zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Call lua function fail.");
-        zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
-        zend_throw_exception_object(&lua_ex);
-        return NULL;
-    }
+	if(ret != LUA_OK) {
+		zval lua_ex;
+		object_init_ex(&lua_ex, lua_exception_ce);
+		zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, retval);
+		zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Call lua function fail.");
+		zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
+		zend_throw_exception_object(&lua_ex);
+		return NULL;
+	}
 
 	return retval;
 } /* }}} */
@@ -653,39 +653,39 @@ PHP_METHOD(lua, eval) {
 
 	bp = lua_gettop(L);
     
-    ret = luaL_loadbuffer(L, statements, len, "line");
-    if (ret == LUA_OK) {
-        ret = lua_pcall(L, 0, LUA_MULTRET, 0);
-    }
+	ret = luaL_loadbuffer(L, statements, len, "line");
+	if (ret == LUA_OK) {
+		ret = lua_pcall(L, 0, LUA_MULTRET, 0);
+	}
     
-    int ret_count;
+	int ret_count;
 
-    ret_count = lua_gettop(L) - bp;
-    if (ret_count > 1) {
-        zval rv;
-        int i = 0;
-        array_init(return_value);
-        for (i = -ret_count; i<0; i++) {
-            php_lua_get_zval_from_lua(L, i, getThis(), &rv);
-            add_next_index_zval(return_value, &rv);
-        }
-    } else if (ret_count) {
-        php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
-    } else {
-        return ;
-    }
+	ret_count = lua_gettop(L) - bp;
+	if (ret_count > 1) {
+		zval rv;
+		int i = 0;
+		array_init(return_value);
+		for (i = -ret_count; i<0; i++) {
+			php_lua_get_zval_from_lua(L, i, getThis(), &rv);
+			add_next_index_zval(return_value, &rv);
+		}
+	} else if (ret_count) {
+		php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
+	} else {
+		return ;
+	}
     
-    lua_pop(L, ret_count);
+	lua_pop(L, ret_count);
     
-    if (ret != LUA_OK) {
-        zval lua_ex;
-        object_init_ex(&lua_ex, lua_exception_ce);
-        zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, return_value);
-        zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Eval lua code fail.");
-        zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
-        zend_throw_exception_object(&lua_ex);
-        return ;
-    }
+	if (ret != LUA_OK) {
+		zval lua_ex;
+		 object_init_ex(&lua_ex, lua_exception_ce);
+		zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, return_value);
+		zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Eval lua code fail.");
+		zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
+		zend_throw_exception_object(&lua_ex);
+		return ;
+	}
 }
 /* }}} */
 
@@ -710,39 +710,39 @@ PHP_METHOD(lua, include) {
 
 	bp = lua_gettop(L);
     
-    ret = luaL_loadfile(L, file);
-    if (ret == LUA_OK) {
-        ret = lua_pcall(L, 0, LUA_MULTRET, 0);
-    }
+	ret = luaL_loadfile(L, file);
+	if (ret == LUA_OK) {
+		ret = lua_pcall(L, 0, LUA_MULTRET, 0);
+	}
     
-    int ret_count;
+	int ret_count;
 
-    ret_count = lua_gettop(L) - bp;
-    if (ret_count > 1) {
-        zval rv;
-        int i = 0;
-        array_init(return_value);
-        for (i = -ret_count; i<0; i++) {
-            php_lua_get_zval_from_lua(L, i, getThis(), &rv);
-            add_next_index_zval(return_value, &rv);
-        }
-    } else if (ret_count) {
-        php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
-    } else {
-        return ;
-    }
+	ret_count = lua_gettop(L) - bp;
+	if (ret_count > 1) {
+		zval rv;
+		int i = 0;
+		array_init(return_value);
+		for (i = -ret_count; i<0; i++) {
+			php_lua_get_zval_from_lua(L, i, getThis(), &rv);
+			add_next_index_zval(return_value, &rv);
+		}
+	} else if (ret_count) {
+		php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
+	} else {
+		return ;
+	}
     
-    lua_pop(L, ret_count);
+	lua_pop(L, ret_count);
     
-    if (ret != LUA_OK) {
-        zval lua_ex;
-        object_init_ex(&lua_ex, lua_exception_ce);
-        zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, return_value);
-        zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Include lua file fail.");
-        zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
-        zend_throw_exception_object(&lua_ex);
-        return ;
-    }
+	if (ret != LUA_OK) {
+		zval lua_ex;
+		object_init_ex(&lua_ex, lua_exception_ce);
+		zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, return_value);
+		zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Include lua file fail.");
+		zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
+		zend_throw_exception_object(&lua_ex);
+		return ;
+	}
 }
 /* }}} */
 
@@ -900,7 +900,7 @@ PHP_MINIT_FUNCTION(lua) {
 	INIT_CLASS_ENTRY(ce, "LuaException", NULL);
 
 	lua_exception_ce = zend_register_internal_class_ex(&ce, zend_exception_get_default());
-    zend_declare_property_null(lua_exception_ce, "err", sizeof("err")-1, ZEND_ACC_PUBLIC);
+	zend_declare_property_null(lua_exception_ce, "err", sizeof("err")-1, ZEND_ACC_PUBLIC);
 
 	return SUCCESS;
 }

--- a/lua.c
+++ b/lua.c
@@ -544,7 +544,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 			   "invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
 			   */
 			zend_throw_exception_ex(NULL, 0, 
-				"invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
+					"invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
 			return NULL;
 		}
 #if (LUA_VERSION_NUM < 502)
@@ -627,7 +627,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 		zval lua_ex;
 		object_init_ex(&lua_ex, lua_exception_ce);
 		zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, retval);
-		zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Call lua function fail.");
+		zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "call to lua function failed");
 		zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
 		zend_throw_exception_object(&lua_ex);
 		return NULL;

--- a/lua.c
+++ b/lua.c
@@ -543,7 +543,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 			   php_error_docref(NULL, E_WARNING,
 			   "invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
 			   */
-			zend_throw_exception_ex(lua_exception_ce, 0,
+            zend_throw_exception_ex(NULL, 0, 
 					"invalid lua function, argument must be an array which contain two elements: array('table', 'method')");
 			return NULL;
 		}
@@ -554,14 +554,14 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 #endif
 		if (LUA_TTABLE != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -1);
-			zend_throw_exception_ex(lua_exception_ce, 0, "invalid lua table '%s'", Z_STRVAL_P(t));
+            zend_throw_exception_ex(NULL, 0, "invalid lua table '%s'", Z_STRVAL_P(t));
 			return NULL;
 		}
 		bp = lua_gettop(L);
 		lua_getfield(L, -1, Z_STRVAL_P(f));
 		if (LUA_TFUNCTION != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -2);
-			zend_throw_exception_ex(lua_exception_ce, 0, "invalid lua table function '%s'.%s", Z_STRVAL_P(t), Z_STRVAL_P(f));
+            zend_throw_exception_ex(NULL, 0, "invalid lua table function '%s'.%s", Z_STRVAL_P(t), Z_STRVAL_P(f));
 			return NULL;
 		}
 	} else if (IS_STRING == Z_TYPE_P(func)) {
@@ -573,7 +573,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 #endif
 		if (LUA_TFUNCTION != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -1);
-			zend_throw_exception_ex(lua_exception_ce, 0, "invalid lua function '%s'", Z_STRVAL_P(func));
+            zend_throw_exception_ex(NULL, 0, "invalid lua function '%s'", Z_STRVAL_P(func));
 			return NULL;
 		}
 	} else if (IS_OBJECT == Z_TYPE_P(func)
@@ -583,7 +583,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 		lua_rawgeti(L, LUA_REGISTRYINDEX, closure_obj->closure);
 		if (LUA_TFUNCTION != lua_type(L, lua_gettop(L))) {
 			lua_pop(L, -1);
-			zend_throw_exception_ex(lua_exception_ce, 0, "call to lua closure failed");
+            zend_throw_exception_ex(NULL, 0, "call to lua closure failed");
 			return NULL;
 		}
 	}
@@ -599,12 +599,7 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 		zend_hash_apply_with_argument(Z_ARRVAL_P(args), (apply_func_arg_t)php_lua_arg_apply_func, (void *)L);
 	}
 
-	if (lua_pcall(L, arg_num, LUA_MULTRET, 0) != LUA_OK) {
-		php_error_docref(NULL, E_WARNING,
-				"call to lua function %s failed", lua_tostring(L, -1));
-		lua_pop(L, lua_gettop(L) - bp);
-		return NULL;
-	}
+	int ret = lua_pcall(L, arg_num, LUA_MULTRET, 0);
 
 	sp = lua_gettop(L) - bp;
 
@@ -627,6 +622,16 @@ static zval *php_lua_call_lua_function(zval *lua_obj, zval *func, zval *args, in
 	if (IS_ARRAY == Z_TYPE_P(func)) {
 		lua_pop(L, -1);
 	}
+    
+    if(ret != LUA_OK) {
+        zval lua_ex;
+        object_init_ex(&lua_ex, lua_exception_ce);
+        zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, retval);
+        zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Call lua function fail.");
+        zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
+        zend_throw_exception_object(&lua_ex);
+        return NULL;
+    }
 
 	return retval;
 } /* }}} */
@@ -647,27 +652,40 @@ PHP_METHOD(lua, eval) {
 	L = (Z_LUAVAL_P(getThis()))->L;
 
 	bp = lua_gettop(L);
-	if ((ret = luaL_loadbuffer(L, statements, len, "line")) != LUA_OK || (ret = lua_pcall(L, 0, LUA_MULTRET, 0) != LUA_OK)) {
-		zend_throw_exception_ex(lua_exception_ce, ret, "%s", lua_tostring(L, -1));
-		lua_pop(L, 1);
-		RETURN_FALSE;
-	} else {
-		int ret_count;
+    
+    ret = luaL_loadbuffer(L, statements, len, "line");
+    if (ret == LUA_OK) {
+        ret = lua_pcall(L, 0, LUA_MULTRET, 0);
+    }
+    
+    int ret_count;
 
-		ret_count = lua_gettop(L) - bp;
-		if (ret_count > 1) {
-			zval rv;
-			int i = 0;
-			array_init(return_value);
-			for (i = -ret_count; i<0; i++) {
-				php_lua_get_zval_from_lua(L, i, getThis(), &rv);
-				add_next_index_zval(return_value, &rv);
-			}
-		} else if (ret_count) {
-			php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
-		}
-		lua_pop(L, ret_count);
-	}
+    ret_count = lua_gettop(L) - bp;
+    if (ret_count > 1) {
+        zval rv;
+        int i = 0;
+        array_init(return_value);
+        for (i = -ret_count; i<0; i++) {
+            php_lua_get_zval_from_lua(L, i, getThis(), &rv);
+            add_next_index_zval(return_value, &rv);
+        }
+    } else if (ret_count) {
+        php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
+    } else {
+        return ;
+    }
+    
+    lua_pop(L, ret_count);
+    
+    if (ret != LUA_OK) {
+        zval lua_ex;
+        object_init_ex(&lua_ex, lua_exception_ce);
+        zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, return_value);
+        zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Eval lua code fail.");
+        zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
+        zend_throw_exception_object(&lua_ex);
+        return ;
+    }
 }
 /* }}} */
 
@@ -691,27 +709,40 @@ PHP_METHOD(lua, include) {
 	L = (Z_LUAVAL_P(getThis()))->L;
 
 	bp = lua_gettop(L);
-	if ((ret = luaL_loadfile(L, file)) != LUA_OK || (ret = lua_pcall(L, 0, LUA_MULTRET, 0) != LUA_OK)) {
-		zend_throw_exception_ex(lua_exception_ce, ret, "%s", lua_tostring(L, -1));
-		lua_pop(L, 1);
-		RETURN_FALSE;
-	} else {
-		int ret_count;
+    
+    ret = luaL_loadfile(L, file);
+    if (ret == LUA_OK) {
+        ret = lua_pcall(L, 0, LUA_MULTRET, 0);
+    }
+    
+    int ret_count;
 
-		ret_count = lua_gettop(L) - bp;
-		if (ret_count > 1) {
-			zval rv;
-			int i = 0;
-			array_init(return_value);
-			for (i = -ret_count; i<0; i++) {
-				php_lua_get_zval_from_lua(L, i, getThis(), &rv);
-				add_next_index_zval(return_value, &rv);
-			}
-		} else if (ret_count) {
-			php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
-		}
-		lua_pop(L, ret_count);
-	}
+    ret_count = lua_gettop(L) - bp;
+    if (ret_count > 1) {
+        zval rv;
+        int i = 0;
+        array_init(return_value);
+        for (i = -ret_count; i<0; i++) {
+            php_lua_get_zval_from_lua(L, i, getThis(), &rv);
+            add_next_index_zval(return_value, &rv);
+        }
+    } else if (ret_count) {
+        php_lua_get_zval_from_lua(L, -1, getThis(), return_value);
+    } else {
+        return ;
+    }
+    
+    lua_pop(L, ret_count);
+    
+    if (ret != LUA_OK) {
+        zval lua_ex;
+        object_init_ex(&lua_ex, lua_exception_ce);
+        zend_update_property(lua_exception_ce, &lua_ex, "err", sizeof("err")-1, return_value);
+        zend_update_property_string(lua_exception_ce, &lua_ex, "message", sizeof("message")-1, "Include lua file fail.");
+        zend_update_property_long(lua_exception_ce, &lua_ex, "code", sizeof("code")-1, ret);
+        zend_throw_exception_object(&lua_ex);
+        return ;
+    }
 }
 /* }}} */
 
@@ -782,7 +813,7 @@ PHP_METHOD(lua, registerCallback) {
 		lua_pushcclosure(L, php_lua_call_callback, 1);
 		lua_setglobal(L, name);
 	} else {
-		zend_throw_exception_ex(lua_exception_ce, 0, "invalid php callback");
+		zend_throw_exception_ex(NULL, 0, "invalid php callback");
 		RETURN_FALSE;
 	}
 
@@ -869,6 +900,7 @@ PHP_MINIT_FUNCTION(lua) {
 	INIT_CLASS_ENTRY(ce, "LuaException", NULL);
 
 	lua_exception_ce = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+    zend_declare_property_null(lua_exception_ce, "err", sizeof("err")-1, ZEND_ACC_PUBLIC);
 
 	return SUCCESS;
 }


### PR DESCRIPTION
当前的lua扩展有一个很大的问题：把一个PHP方法registerCallback给lua之后，如果lua调用这个方法出现php的异常，lua的代码还是会继续往下走，示例：
```
$lua->registerCallback("test", function() {
    throw new \Exception("test");
});

$lua->eval(<<<LUA
test() -- php 抛出了异常
print("Hello php.") -- 代码继续走到了这里
LUA
);
```

---

以上是题外话，但是和这个改进相关。当lua侧代码出现了问题需要终止的时候，只有一种终止方法，那就是error方法。php侧需要捕获这个异常做一些特殊处理的时候只需要判断 `$e instanceof \LuaException`。其次 php 需要得到 error 方法的参数，示例：
```
try {
    $lua->eval("error({code=1,message='test'})");
} catch(\LuaException $e) {
    var_dump($e->err);
}
```