### PR TITLE
MacOS compatibility

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -49,7 +49,7 @@ if test "$PHP_LUA" != "no"; then
     LUA_LIB_DIR=$PHP_LUA/$PHP_LIBDIR
   else
     AC_MSG_CHECKING(for lua library in default path)
-    for i in /usr/$PHP_LIBDIR /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu; do
+    for i in /usr/$PHP_LIBDIR /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu /usr/local/lib; do
       if test -r $i/${LUA_LIB_NAME}.${SHLIB_SUFFIX_NAME} -o -r $i/${LUA_LIB_NAME}.a; then
         LUA_LIB_DIR=$i
         AC_MSG_RESULT(found in $i)


### PR DESCRIPTION
MacOS has different lib path for liblua. This PR adds /usr/local/lib to the list of paths where it looks for it